### PR TITLE
feat: afford disabling highlighting per ft and bt

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -21,12 +21,16 @@ visual-whitespace does not require initialization. To install it with the defaul
 
 ```lua
     opts = {
-      highlight = { link = 'Visual' },
+      highlight = { link = "Visual" },
       space_char = '·',
       tab_char = '→',
       nl_char = '↲',
-      cr_char = '←'
-      enabled = true
+      cr_char = '←',
+      enabled = true,
+      excluded = {
+        filetypes = {},
+        buftypes = {}
+      }
     },
 ```
 


### PR DESCRIPTION
The user should be able to disable white space highlighting on specific buffertypes or filetypes. This commit allows for this functionality.

A "thank you" to Reddit user EstudiandoAjedrez for pointing me to vim.schedule().