### PR TITLE
Check global VisualNonText highlight

### DIFF
--- a/lua/visual-whitespace.lua
+++ b/lua/visual-whitespace.lua
@@ -204,7 +204,12 @@ M.setup = function(user_cfg)
     ['\r'] = CFG['cr_char']
   }
 
-  api.nvim_set_hl(0, 'VisualNonText', CFG['highlight'])
+  local global_highlight = api.nvim_get_hl(0, { name = 'VisualNonText' })
+  if not vim.tbl_isempty(global_highlight) then
+    api.nvim_set_hl(0, 'VisualNonText', global_highlight)
+  else
+    api.nvim_set_hl(0, 'VisualNonText', CFG['highlight'])
+  end
 
   aucmd({ "BufEnter", "WinEnter" }, {
     group = core_augrp,

--- a/readme.md
+++ b/readme.md
@@ -34,6 +34,12 @@ visual-whitespace does not require initialization. To install it with the defaul
     },
 ```
 
+The highlight can also be set using the Nvim's Lua API:
+
+```lua
+vim.api.nvim_set_hl(0, "VisualNonText", { link = "Visual" })
+```
+
 visual-whitespace affords the following user-facing functions:
 
 | Lua                                     | Description                                                      |


### PR DESCRIPTION
Checks if user or colorscheme sets a highlight for the VisualNonText
group.

Caveats:
- `vim.tbl_isempty()` is needed because when not set, `nvim_get_hl` returns
  `vim.empty_dict()` object (and not {})
- lua_ls might show "Cannot assign `vim.api.keyset.get_hl_info` to
  parameter `vim.api.keyset.highlight`", but this is probably a type
  bug in nvims api


Closes #15.
