### PR TITLE
Add lazy.nvim spec for auto lazyloading

### DIFF
--- a/lazy.lua
+++ b/lazy.lua
@@ -1,0 +1,5 @@
+return {
+  "mcauley-penny/visual-whitespace.nvim",
+  opts = {},
+  event = "ModeChanged *:[vV]",
+}

--- a/lua/visual-whitespace.lua
+++ b/lua/visual-whitespace.lua
@@ -211,7 +211,7 @@ M.setup = function(user_cfg)
     api.nvim_set_hl(0, 'VisualNonText', CFG['highlight'])
   end
 
-  aucmd({ "BufEnter", "WinEnter" }, {
+  aucmd({ "BufEnter", "WinEnter", "User" }, {
     group = core_augrp,
     callback = vim.schedule_wrap(function()
       local prev_enabled = CFG.enabled
@@ -222,6 +222,8 @@ M.setup = function(user_cfg)
       end
     end)
   })
+  -- Run the autocmd above on already existing buffer (when lazy loaded)
+  vim.api.nvim_exec_autocmds("User", { group = core_augrp })
 
   init_aucmds()
 end

--- a/readme.md
+++ b/readme.md
@@ -11,10 +11,7 @@ Reveal whitespace characters in visual mode, similar to VSCode.
 To install the plugin with the default settings using Lazy:
 
 ```lua
-  {
-    'mcauley-penney/visual-whitespace.nvim',
-    config = true
-  }
+  { 'mcauley-penney/visual-whitespace.nvim' }
 ```
 
 `visual-whitespace` comes with the following default settings:


### PR DESCRIPTION
Don't know if this is something you would like, but this adds a Lazy.nvim [Package spec](https://lazy.folke.io/packages). This basically sets some lazy options as default for everyone installing your plugin with lazy. This means that (1) they do not have to set `opts` if they use the default and (2) this plugin automatically lazyloads on entering visual mode.

This only affects lazy.nvim users. Since they use lazy.nvim, I think they also want to lazy-load plugins. It's hard for users to figure out what the best lazyload approach is for every package. This circumvents that problem.