### PR TITLE
feat: use 'default' option of nvim_set_hl

### DIFF
--- a/lua/visual-whitespace.lua
+++ b/lua/visual-whitespace.lua
@@ -7,7 +7,7 @@ local core_augrp = api.nvim_create_augroup("VisualWhitespace", { clear = true })
 local M = {}
 local NS_ID = api.nvim_create_namespace('VisualWhitespace')
 local CFG = {
-  highlight = { link = "Visual" },
+  highlight = { link = "Visual", default = true },
   space_char = '·',
   tab_char = '→',
   nl_char = '↲',
@@ -203,13 +203,7 @@ M.setup = function(user_cfg)
     ['\n'] = CFG['nl_char'],
     ['\r'] = CFG['cr_char']
   }
-
-  local global_highlight = api.nvim_get_hl(0, { name = 'VisualNonText' })
-  if not vim.tbl_isempty(global_highlight) then
-    api.nvim_set_hl(0, 'VisualNonText', global_highlight)
-  else
-    api.nvim_set_hl(0, 'VisualNonText', CFG['highlight'])
-  end
+  api.nvim_set_hl(0, 'VisualNonText', CFG['highlight'])
 
   aucmd({ "BufEnter", "WinEnter" }, {
     group = core_augrp,


### PR DESCRIPTION
In https://github.com/mcauley-penney/visual-whitespace.nvim/pull/17 I introduced a way to set the higlighting using `vim.api.nvim_set_hl`, by checking if a user had already done that. Turns out, nvim can do this out of the box using `default = true` in the default highlight group. See [:h hi-default](https://neovim.io/doc/user/syntax.html#%3Ahi-default) and [:h nvim_set_hl()](https://neovim.io/doc/user/api.html#nvim_set_hl()).

This changes behaviour slightly, but only in the edge case that the user defined a highlight in both their setup() argument as well as with `nvim_set_hl`.

- Before: hl set with `nvim_set_hl` would win.
- After: hl set with `setup({ highlight = ... })` wins. 

I think the after version also makes more sense, although it wasn't the goal of this PR.