### PR TITLE
feat: allow running plugin without calling setup()

### DIFF
--- a/lua/visual-whitespace.lua
+++ b/lua/visual-whitespace.lua
@@ -8,7 +8,7 @@ local HL = "VisualNonText"
 local STATE = { user_enabled = true, active = false }
 
 local NBSP = v.fn.nr2char(160)
-local WS_RX = [[\v( |\t|\r|]] .. NBSP .. ')'
+local WS_RX = [[\v( |\t|\r|]] .. NBSP .. ")"
 
 local CFG = {
   enabled = true,
@@ -233,8 +233,6 @@ function M.toggle()
 end
 
 function M.setup(user_cfg)
-  DEFAULT_CFG = v.tbl_deep_extend("force", {}, CFG, user_cfg or {})
-
   local lcs_defaults = read_opt_listchars()
 
   DEFAULT_CFG =

--- a/plugin/visual_whitespace.lua
+++ b/plugin/visual_whitespace.lua
@@ -1,0 +1,12 @@
+local cfg = vim.g.visual_whitespace or {}
+
+if type(cfg) == "function" then
+  local ok, result = pcall(cfg)
+  if ok and type(result) == "table" then
+    cfg = result
+  else
+    cfg = {}
+  end
+end
+
+require("visual-whitespace").setup(cfg)


### PR DESCRIPTION
If the user would like to initialize the plugin without calling setup(), they can. They can also configure the plugin through vim.g.visual_whitespace

Closes #39