### PR TITLE
fix: revise highlight group configuration

### DIFF
--- a/lua/visual-whitespace.lua
+++ b/lua/visual-whitespace.lua
@@ -237,6 +237,8 @@ function M.setup(user_cfg)
 
   DEFAULT_CFG =
     v.tbl_deep_extend("force", { list_chars = lcs_defaults }, CFG, user_cfg)
+	DEFAULT_CFG.highlight = user_cfg.highlight or CFG.highlight
+	DEFAULT_CFG.highlight.force = true
 
   STATE.user_enabled = DEFAULT_CFG.enabled
 

--- a/lua/visual-whitespace.lua
+++ b/lua/visual-whitespace.lua
@@ -237,8 +237,8 @@ function M.setup(user_cfg)
 
   DEFAULT_CFG =
     v.tbl_deep_extend("force", { list_chars = lcs_defaults }, CFG, user_cfg)
-	DEFAULT_CFG.highlight = user_cfg.highlight or CFG.highlight
-	DEFAULT_CFG.highlight.force = true
+  DEFAULT_CFG.highlight = user_cfg.highlight or CFG.highlight
+  DEFAULT_CFG.highlight.force = true
 
   STATE.user_enabled = DEFAULT_CFG.enabled
 


### PR DESCRIPTION
- Override highlight group definition with user-defined one, if present
- Set `force = true` to allow re-defining the HL group if calling `setup` multiple times

Closes #41 