### PR TITLE
fix: Vim:E976: Using a Blob as a String

### DIFF
--- a/lua/visual-whitespace.lua
+++ b/lua/visual-whitespace.lua
@@ -139,7 +139,8 @@ end
 
 ------- Extmark utilities
 local function match_ws_pos(line, char_idx)
-  local res = v.fn.matchstrpos(line, WS_RX, char_idx - 1)
+  local res = vim.F.npcall(v.fn.matchstrpos, line, WS_RX, char_idx - 1)
+  if not res then return nil, nil end
   local s_char = tonumber(res[2])
   if s_char == -1 then return nil, nil end
 


### PR DESCRIPTION
```
Lua: Vim:E976: Using a Blob as a Stringstack traceback:[C]: in function
'matchstrpos'...an/lazy/visual-whitespace.nvim/lua/visual-whitespace.lua:142:
in function
'match_ws_pos'...an/lazy/visual-whitespace.nvim/lua/visual-whitespace.lua:157:
in function 'marks_for_line'
```

It occasionally happened when I do some visual selection in quickfix list.
